### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,4 +65,3 @@ jobs:
         env_vars: OS,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: true
-        path_to_write_report: ./coverage/codecov_report.gz


### PR DESCRIPTION
Looks like this codecov action version doesn't support path_to_write_report even though it is present in the documentation 
-> https://github.com/codecov/codecov-action